### PR TITLE
Update KDE SDK to 6.5

### DIFF
--- a/com.obsproject.Studio.Plugin.GStreamerVaapi.yml
+++ b/com.obsproject.Studio.Plugin.GStreamerVaapi.yml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.GStreamerVaapi
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.4
+sdk: org.kde.Sdk//6.5
 build-extension: true
 separate-locales: false
 appstream-compose: false


### PR DESCRIPTION
OBS Studio 30.0 has been released and now uses the KDE Runtime 6.5.