### PR TITLE
Remove "Plugin" suffix from name

### DIFF
--- a/com.obsproject.Studio.Plugin.GStreamerVaapi.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.GStreamerVaapi.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="addon">
   <id>com.obsproject.Studio.Plugin.GStreamerVaapi</id>
   <extends>com.obsproject.Studio</extends>
-  <name>GStreamer VA-API Plugin</name>
+  <name>GStreamer VA-API</name>
   <summary>GStreamer-based VA-API encoder</summary>
   <url type="homepage">https://github.com/fzwoch/obs-vaapi</url>
   <releases>


### PR DESCRIPTION
This is the policy for OBS Studio plugins on Flathub, and new plugins  have been following it for some time now. Remove the suffix from the name.
